### PR TITLE
Use GOTOOLDIR

### DIFF
--- a/go-fast-compile
+++ b/go-fast-compile
@@ -4,9 +4,10 @@ set -euo pipefail
 
 export WORK="/tmp/go-fast-compile$(pwd | sed "s|^$GOPATH/src||")"
 export GOBIN="$WORK"
+export GOTOOLDIR=`go env GOTOOLDIR`
 
 eval "$(
     go install -x -n "$@" 2>&1 \
-        | grep -vP '^(/usr/lib/go/pkg/tool/([^/]+)/link|mv) ' \
+        | grep -vP '^(${GOTOOLDIR}/link|mv) ' \
         | sed -r '/^CGO_LDFLAGS=/s/" "/ /g'
 )"


### PR DESCRIPTION
`GOTOOLDIR` provides more flexibility.
### e.g.

``` bash
$ go env GOTOOLDIR
/home/yyoshiki41/.gvm/gos/go1.7/pkg/tool/darwin_amd64
```
### help

``` bash
$ go env --help
usage: env [var ...]

Env prints Go environment information.

By default env prints information as a shell script
(on Windows, a batch file).  If one or more variable
names is given as arguments,  env prints the value of
each named variable on its own line.
```

thanks 😄

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kovetskiy/go-fast/3)

<!-- Reviewable:end -->
